### PR TITLE
ワークフローを簡略化する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build
 on:
   push:
-    branches: [ main ]
+    branches: [main]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -10,7 +10,7 @@ jobs:
       - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: "18.x"
       - name: Install dependencies
         working-directory: ./akiyuki
         run: npm ci || npm install --legacy-peer-deps
@@ -20,12 +20,6 @@ jobs:
       - name: Build
         working-directory: ./akiyuki
         run: npm run build
-      - name: Preparation for static site
-        run: |
-          mkdir -p docs/snake
-          mkdir -p docs/boid-algorithm
-          cp ./docs/index.html ./docs/snake
-          cp ./docs/index.html ./docs/boid-algorithm
       - name: Commit and push changes
         run: |
           git config --global user.name 'GitHub Actions'

--- a/akiyuki/package.json
+++ b/akiyuki/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build && mkdir ../docs/snake && cp ../docs/index.html ../docs/snake/index.html",
+    "build": "vue-cli-service build",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {

--- a/akiyuki/src/router/index.ts
+++ b/akiyuki/src/router/index.ts
@@ -1,4 +1,4 @@
-import { createRouter, createWebHistory } from 'vue-router'
+import { createRouter, createWebHashHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
 // import SnakeGame from "../views/SnakeGame.vue"
 // import NotFound from "../views/NotFound.vue"
@@ -27,7 +27,7 @@ const routes = [
 ]
 
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHashHistory(),
   routes
 })
 


### PR DESCRIPTION
ルーティングに URL Hash を使用するように変更しました。これにより、ビルド時の新規ディレクトリ作成プロセスが不要になります。これは #3 の解決案を代替します。

## 主な変更点

アプリケーションの URL に `#` が含まれるようになります。(e.g. `https://llillillj.github.io/#/`, `https://llillillj.github.io/#/snake-geme`)

## 各コミットの詳細

このプルリクエストには以下の変更が含まれます。

- 6f950d73d9f4c6d5856dc1aedc5a918d9315881e : URL Hash に変更するため `createWebHistory()` の代わりに `createWebHashHistory()` を使用するようにしました。
- c310265510a9153eda35d9958a13ac5838896392 : ワークフローの不要なコマンドを削除しました。

